### PR TITLE
cd /d instead of cd

### DIFF
--- a/git-latexdiff.bat
+++ b/git-latexdiff.bat
@@ -57,29 +57,29 @@ latexpand %2.tex -o temp_%2.tex
 move temp_%2.tex %TEMP%\cleandiff\PREV.tex
 
 ::go back to master
-cd %HERE%
+cd /d %HERE%
 git checkout -f %3
 
 ::move the cleandiff and run latexdiff
-cd %TEMP%\cleandiff
+cd /d  %TEMP%\cleandiff
 latexdiff PREV.tex HEAD.tex > diff.tex
 latexdiff PREV.bbl HEAD.bbl --append-textcmd="bibinfo",  > diff.bbl
 copy diff.tex %HERE%\diff.tex
 
 ::generate pdf at %HERE% because the environment(sty/bst) needed
-cd %HERE%
+cd /d %HERE%
 pdflatex -interaction=batchmode --output-directory=%TEMP%\cleandiff diff
 pdflatex -interaction=batchmode --output-directory=%TEMP%\cleandiff diff
 
 
 ::move pdf back up
-cd %TEMP%\cleandiff
+cd /d %TEMP%\cleandiff
 copy diff.pdf %HERE%\diff.pdf
 ::cleanup
 del /F /Q *.*
 
 ::now restore backup
-cd %TEMP%\backup
+cd /d %TEMP%\backup
 copy *.lof %HERE%\*.lof
 copy *.lot %HERE%\*.lot
 copy *.toc %HERE%\*.lof
@@ -94,8 +94,8 @@ copy *.tex %HERE%\*.tex
 copy *.bib %HERE%\*.bib
 ::and clean
 del /F /Q *.*
-cd %TEMP%
+cd /d %TEMP%
 rmdir cleandiff
 rmdir backup
-cd %HERE%
+cd /d %HERE%
 del diff.tex


### PR DESCRIPTION
use `cd /d` instead of   `cd`, in case the latex project and temp folder are in different drivers. 